### PR TITLE
Revamp

### DIFF
--- a/backlight_control.c
+++ b/backlight_control.c
@@ -35,11 +35,14 @@ FILE *open_file(char *name) {
 int main(int argc, char **argv) {
 	if (argc != 2) {
 		usage(argv[0]);
+
 		return EXIT_FAILURE;
 	}
+
 	int value = strtol(argv[1], NULL, 10);
 	FILE *brightness = open_file(BRIGHTNESS_FILE);
 	int brightness_value = MIN_BRIGHTNESS;
+
 	switch (argv[1][0]) {
 		case '+':
 		case '-':
@@ -49,9 +52,12 @@ int main(int argc, char **argv) {
 		default:
 			brightness_value = MAX_BRIGHTNESS * value / 100;
 	}
+
 	brightness_value = MIN(brightness_value, MAX_BRIGHTNESS);
 	brightness_value = MAX(brightness_value, MIN_BRIGHTNESS);
+
 	fprintf(brightness, "%d", brightness_value);
 	fclose(brightness);
+
 	return EXIT_SUCCESS;
 }

--- a/backlight_control.c
+++ b/backlight_control.c
@@ -39,16 +39,33 @@ int main(int argc, char **argv) {
 		return EXIT_FAILURE;
 	}
 
-	int value = strtol(argv[1], NULL, 10);
+	char *endptr;
+
+	long int value = strtol(argv[1], &endptr, 10);
+
+	if (endptr == argv[1]) {
+		fputs("brightness value must be an integer\n", stderr);
+
+		return EXIT_FAILURE;
+	}
+
+	if (!((value < 0 ? value *= -1 : value) >= 1 && value <= 100)) {
+		fputs("brightness value must be between 1 and 100 (inclusively)\n", stderr);
+
+		return EXIT_FAILURE;
+	}
+
 	FILE *brightness = open_file(BRIGHTNESS_FILE);
-	int brightness_value = MIN_BRIGHTNESS;
+	long int brightness_value = MIN_BRIGHTNESS;
 
 	switch (argv[1][0]) {
 		case '+':
 		case '-':
-			fscanf(brightness, "%d", &brightness_value);
+			fscanf(brightness, "%ld", &brightness_value);
 			brightness_value += MAX_BRIGHTNESS * value / 100;
+
 			break;
+
 		default:
 			brightness_value = MAX_BRIGHTNESS * value / 100;
 	}
@@ -56,7 +73,7 @@ int main(int argc, char **argv) {
 	brightness_value = MIN(brightness_value, MAX_BRIGHTNESS);
 	brightness_value = MAX(brightness_value, MIN_BRIGHTNESS);
 
-	fprintf(brightness, "%d", brightness_value);
+	fprintf(brightness, "%ld", brightness_value);
 	fclose(brightness);
 
 	return EXIT_SUCCESS;

--- a/backlight_control.c
+++ b/backlight_control.c
@@ -14,8 +14,7 @@
 
 void usage(char *name) {
 	printf(
-		"Usage: %1$s [+|-]<value>\n"
-		"\n"
+		"Usage: %1$s [+|-]<value>\n\n"
 		"Examples:\n"
 		"\t%1$s +10\n"
 		"\t%1$s -10\n"

--- a/backlight_control.c
+++ b/backlight_control.c
@@ -56,24 +56,27 @@ int main(int argc, char **argv) {
 	}
 
 	FILE *brightness = open_file(BRIGHTNESS_FILE);
-	long int brightness_value = MIN_BRIGHTNESS;
+	float brightness_value;
+
+	fscanf(brightness, "%e", &brightness_value);
 
 	switch (argv[1][0]) {
 		case '+':
-		case '-':
-			fscanf(brightness, "%ld", &brightness_value);
-			brightness_value += MAX_BRIGHTNESS * value / 100;
+			brightness_value += MAX_BRIGHTNESS * ((float)value / 100.0);
 
 			break;
+		case '-':
+			brightness_value -= MAX_BRIGHTNESS * ((float)value / 100.0);
 
+			break;
 		default:
-			brightness_value = MAX_BRIGHTNESS * value / 100;
+			brightness_value = MAX_BRIGHTNESS * ((float)value / 100.0);
 	}
 
 	brightness_value = MIN(brightness_value, MAX_BRIGHTNESS);
 	brightness_value = MAX(brightness_value, MIN_BRIGHTNESS);
 
-	fprintf(brightness, "%ld", brightness_value);
+	fprintf(brightness, "%.0f", brightness_value);
 	fclose(brightness);
 
 	return EXIT_SUCCESS;

--- a/backlight_control.c
+++ b/backlight_control.c
@@ -12,7 +12,7 @@
 #define MAX(a, b) ((a > b) ? a : b)
 #define MIN(a, b) ((a < b) ? a : b)
 
-void print_usage(char *name) {
+void usage(char *name) {
 	printf(
 		"Usage: %1$s [+|-]<value>\n"
 		"\n"
@@ -35,7 +35,7 @@ FILE *open_file(char *name) {
 
 int main(int argc, char **argv) {
 	if (argc != 2) {
-		print_usage(argv[0]);
+		usage(argv[0]);
 		return EXIT_FAILURE;
 	}
 	int value = strtol(argv[1], NULL, 10);

--- a/backlight_control.c
+++ b/backlight_control.c
@@ -23,15 +23,6 @@ void usage(char *name) {
 	);
 }
 
-FILE *open_file(char *name) {
-	FILE *file;
-	if (!(file = fopen(name, "r+"))) {
-		fprintf(stderr, "failed to open %s\n", name);
-		exit(EXIT_FAILURE);
-	}
-	return file;
-}
-
 int main(int argc, char **argv) {
 	if (argc != 2) {
 		usage(argv[0]);
@@ -55,7 +46,14 @@ int main(int argc, char **argv) {
 		return EXIT_FAILURE;
 	}
 
-	FILE *brightness = open_file(BRIGHTNESS_FILE);
+	FILE *brightness;
+
+	if (!(brightness = fopen(BRIGHTNESS_FILE, "r+"))) {
+		fprintf(stderr, "failed to open %s\n", BRIGHTNESS_FILE);
+
+		return (EXIT_FAILURE);
+	}
+
 	float brightness_value;
 
 	fscanf(brightness, "%e", &brightness_value);

--- a/backlight_control.c
+++ b/backlight_control.c
@@ -46,9 +46,9 @@ int main(int argc, char **argv) {
 		return EXIT_FAILURE;
 	}
 
-	FILE *brightness;
+	FILE *fp;
 
-	if (!(brightness = fopen(BRIGHTNESS_FILE, "r+"))) {
+	if (!(fp = fopen(BRIGHTNESS_FILE, "r+"))) {
 		fprintf(stderr, "failed to open %s\n", BRIGHTNESS_FILE);
 
 		return (EXIT_FAILURE);
@@ -56,7 +56,7 @@ int main(int argc, char **argv) {
 
 	float brightness_value;
 
-	fscanf(brightness, "%e", &brightness_value);
+	fscanf(fp, "%e", &brightness_value);
 
 	switch (argv[1][0]) {
 		case '+':
@@ -74,8 +74,8 @@ int main(int argc, char **argv) {
 	brightness_value = MIN(brightness_value, MAX_BRIGHTNESS);
 	brightness_value = MAX(brightness_value, MIN_BRIGHTNESS);
 
-	fprintf(brightness, "%.0f", brightness_value);
-	fclose(brightness);
+	fprintf(fp, "%.0f", brightness_value);
+	fclose(fp);
 
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Previously (*i.e* [commit 9a79e0d](https://github.com/Hendrikto/backlight_control/commit/9a79e0df32d73a93ff03b4cee8e2261c42cc2748)),
`backlight_control` would not validate the `value` argument and set unexpected brightness values.

For example:

```shell
backlight_control -100
```

*Sets the current brigthness to* `0`.

Although [Linux ensures](https://elixir.bootlin.com/linux/v6.3.8/source/include/linux/backlight.h#L182) the value set in `/sys/class/backlight/<backlight>/brightness` is between `0` and `max_brightness`, I think it would be nice to notify the user of invalid arguments.

Thanks for reading and I am open to feedback.
